### PR TITLE
small tweaks that should get this to work

### DIFF
--- a/rpi/tools/mount-raspbian.sh
+++ b/rpi/tools/mount-raspbian.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+. ./functions.sh --source-only
+
 BOOT_MNT_POINT=/mnt/boot
 ROOT_MNT_POINT=/mnt/root
 
-echo "MOUNT RASPBIAN IMAGE: "$1
+INPUT_IMAGE=$1
+echo "MOUNT RASPBIAN IMAGE: "$INPUT_IMAGE
 if [ ! -d $BOOT_MNT_POINT ]; then
     mkdir -p $BOOT_MNT_POINT
 fi
@@ -11,19 +14,13 @@ if [ ! -d $ROOT_MNT_POINT ]; then
     mkdir -p $ROOT_MNT_POINT
 fi
 
-# The boot partition is Id 'c' and Type W95 FAT32
-# The root partition is Id '83' and Type Linux
-# We'll just use the type to grep to find the line in fdisk
-BOOTPARTPATTERN="W95"
-ROOTPARTPATTERN="Linux"
-# This is a very inefficient way to get the offsets.
-BOOT_START=`fdisk -l $1 | grep $BOOTPARTPATTERN | awk '{print $2}'`
-BOOT_SECTORS=`fdisk -l $1 | grep $BOOTPARTPATTERN | awk '{print $4}'`
-ROOT_START=`fdisk -l $1 | grep $ROOTPARTPATTERN | awk '{print $2}'`
-ROOT_SECTORS=`fdisk -l $1 | grep $ROOTPARTPATTERN | awk '{print $4}'`
-if [ "$BOOT_START" = "*" ] ; then
-    BOOT_START=`fdisk -l $1 | grep $BOOTPARTPATTERN | awk '{print $3}'`
-fi
+START_SECTORS=$( get_start_and_sectors $INPUT_IMAGE W95 )
+BOOT_START=$(echo $START_SECTORS | cut -f1 -d' ')
+BOOT_SECTORS=$(echo $START_SECTORS | cut -f2 -d' ')
+
+START_SECTORS=$( get_start_and_sectors $INPUT_IMAGE Linu )
+ROOT_START=$(echo $START_SECTORS | cut -f1 -d' ')
+ROOT_SECTORS=$(echo $START_SECTORS | cut -f2 -d' ')
 echo "boot start: $BOOT_START, sectors: $BOOT_SECTORS"
 echo "root start: $ROOT_START, sectors: $ROOT_SECTORS"
 
@@ -32,7 +29,7 @@ BOOT_LIMIT=$((BOOT_SECTORS * 512))
 ROOT_OFFSET=$((ROOT_START * 512))
 ROOT_LIMIT=$((ROOT_SECTORS * 512))
 
-mount -o loop,offset=$BOOT_OFFSET,sizelimit=$BOOT_LIMIT $1 $BOOT_MNT_POINT
-mount -o loop,offset=$ROOT_OFFSET,sizelimit=$ROOT_LIMIT $1 $ROOT_MNT_POINT
+mount -o loop,offset=$BOOT_OFFSET,sizelimit=$BOOT_LIMIT $INPUT_IMAGE $BOOT_MNT_POINT
+mount -o loop,offset=$ROOT_OFFSET,sizelimit=$ROOT_LIMIT $INPUT_IMAGE $ROOT_MNT_POINT
 
 exit


### PR DESCRIPTION
 - reordered losetup arguments. "-f" is use a file for the block device, not the image. Moved the image argument to the end, so -f uses the first available loopback device.
 - correctly calculate the sectors for the root partition when creating the map file. (Failed to subtract the space up to the boot offset when calculating the root sectors)
 - comment out the attempted fixes at the end of resize. I don't think those are needed, and they don't work anyway.